### PR TITLE
Add documentation for hcmusic plugin packages

### DIFF
--- a/plugins/hcmusic/audio/README.md
+++ b/plugins/hcmusic/audio/README.md
@@ -1,3 +1,214 @@
 hcmusic.audio
 ===
-This module provides audio functionalities to Inspector.
+This module provides audio functionalities to Inspector, primarily through classes defined in `AudioDevice.py`. These classes allow for capturing, processing, and outputting audio streams.
+
+## AudioDevice.py
+
+`AudioDevice.py` contains several QObject-based classes for audio handling:
+
+1.  **`AudioDiscoveryModelProvider`**: Discovers available audio input and output devices and provides models for QML.
+    *   `inputDeviceModel`: A model listing available input devices.
+    *   `defaultInputDeviceIndex`: The system's default input device index.
+    *   `defaultOutputDeviceIndex`: The system's default output device index.
+    *   `refresh()`: Slot to refresh the list of devices.
+
+2.  **`AudioInputDevice`**: A `Node` for capturing audio from a selected input device. This is often the primary class used for getting audio into the application.
+
+3.  **`AudioOutputDevice`**: A `Node` for sending audio to a selected output device.
+
+4.  **`RemoteAudioDevice`**: A `Node` for receiving audio data over a network connection.
+
+### AudioInputDevice
+
+The `AudioInputDevice` class is designed to capture audio from a hardware input and provide it as a data stream for further processing.
+
+**Purpose:**
+
+To select an audio input, configure its parameters (sample rate, buffer size, channels), and continuously provide blocks of audio samples as a `Signal1D` output.
+
+**Properties:**
+
+*   **`active`**: `bool`
+    *   Controls whether the audio device is currently capturing audio. Setting it to `true` starts capturing, and `false` stops it.
+*   **`rate`**: `int`
+    *   The desired sample rate in Hz (e.g., 44100, 48000).
+    *   The device attempts to open the stream with this rate.
+*   **`channels`**: `int`
+    *   The number of audio channels to capture (e.g., 1 for mono, 2 for stereo).
+*   **`bufferLength`**: `int`
+    *   The number of audio frames per buffer. This defines the size of the audio chunk delivered at each update. This is akin to `sampleSize` in terms of defining data block length.
+*   **`deviceIndex`**: `int`
+    *   The index of the audio input device to use. This can be obtained from `AudioDiscoveryModelProvider.inputDeviceModel` or `AudioDiscoveryModelProvider.defaultInputDeviceIndex`. This corresponds to the `device` property.
+*   **`output`**: `Signal1D` (read-only)
+    *   The output signal that carries the captured audio data. The data is a NumPy array accessible via `output.numpy_array`.
+*   **`volume`**: This class does not have a direct `volume` control property. Volume adjustments would typically be handled by downstream processing nodes.
+
+**Signals:**
+
+*   **`activeChanged()`**: Emitted when the `active` property changes.
+*   **`rateChanged()`**: Emitted when the `rate` property changes.
+*   **`channelsChanged()`**: Emitted when the `channels` property changes.
+*   **`bufferLengthChanged()`**: Emitted when the `bufferLength` property changes.
+*   **`deviceIndexChanged()`**: Emitted when the `deviceIndex` property changes.
+*   **`outputChanged()`**: Emitted when the `output` signal object itself is changed (e.g., re-allocated).
+*   **`output.update(offset, length)`**: This signal, from the `QtSignal1D` object held by the `output` property, is emitted whenever new audio data is available. This effectively serves as the `dataAvailable` signal. `offset` is typically 0 and `length` is `bufferLength`.
+*   **`error`**: There isn't a specific `error(string)` signal. Errors during device operation (e.g., unsupported format, device disconnection) will typically raise Python exceptions. These might be caught by the QML environment or Python application logic.
+
+**Slots/Methods:**
+
+*   **`active` property setter (effectively `start()`/`stop()`):**
+    *   Setting `active = true` initializes and starts the audio stream.
+    *   Setting `active = false` stops and closes the audio stream.
+*   **`initialize()`**: Called internally or can be called to ensure the output buffer is allocated. If `active` is true, it will also attempt to open the device.
+*   **`openDevice()`**: (Primarily internal) Opens the audio stream. Automatically called when `active` becomes true.
+*   **`closeDevice()`**: (Primarily internal) Closes the audio stream. Automatically called when `active` becomes false or on application quit.
+*   **`read()`**: There is no direct `read()` method to pull data. Instead, `AudioInputDevice` pushes data by emitting the `output.update` signal when a new buffer is ready.
+
+**QML Example for AudioInputDevice:**
+
+```qml
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import hcmusic.audio 1.0 // Assuming the module is registered
+
+ApplicationWindow {
+    visible: true
+    width: 640
+    height: 480
+    title: "Audio Input Example"
+
+    AudioDiscoveryModelProvider {
+        id: audioDiscovery
+        Component.onCompleted: {
+            console.log("Default input device index:", defaultInputDeviceIndex)
+            // You might want to refresh if devices change after startup
+            // refresh()
+        }
+    }
+
+    AudioInputDevice {
+        id: audioInput
+        active: false // Start inactive
+        deviceIndex: audioDiscovery.defaultInputDeviceIndex // Use default device
+        rate: 44100
+        channels: 1
+        bufferLength: 1024
+
+        // Accessing the output signal (Signal1D)
+        // output.numpy_array will contain the data when output.update is emitted
+
+        // Example: Connecting to the dataAvailable equivalent
+        Component.onCompleted: {
+            output.update.connect(processAudioData)
+        }
+
+        function processAudioData(offset, length) {
+            // console.log("Audio data received:", length, "samples at offset", offset);
+            // audioInput.output.numpy_array contains the actual audio data
+            // Example: Calculate RMS (requires a custom C++ or Python backend for complex processing)
+            // For pure QML, you might send this data to another component or a custom processing element.
+        }
+    }
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 10
+
+        ComboBox {
+            id: deviceSelector
+            textRole: "name"
+            valueRole: "deviceIndex"
+            model: audioDiscovery.inputDeviceModel
+            currentIndex: audioDiscovery.inputDeviceModel.count > 0 ? 0 : -1 // Select first if available
+            onCurrentIndexChanged: {
+                if (currentIndex !== -1) {
+                    audioInput.deviceIndex = model.get(currentIndex).deviceIndex;
+                }
+            }
+        }
+
+        Button {
+            text: audioInput.active ? "Stop Capture" : "Start Capture"
+            onClicked: {
+                audioInput.active = !audioInput.active;
+            }
+        }
+
+        Label {
+            text: "Status: " + (audioInput.active ? "Capturing" : "Stopped")
+        }
+        Label {
+            text: "Sample Rate: " + audioInput.rate + " Hz"
+        }
+        Label {
+            text: "Channels: " + audioInput.channels
+        }
+        Label {
+            text: "Buffer Length: " + audioInput.bufferLength + " samples"
+        }
+    }
+}
+```
+
+### AudioOutputDevice
+
+The `AudioOutputDevice` class is designed to play back audio data through a hardware output.
+
+**Purpose:**
+
+To select an audio output device, configure its parameters (sample rate, buffer size, channels), and play audio data provided via its `input` (Signal1D) property.
+
+**Properties:**
+
+*   **`active`**: `bool` - Controls if the device is playing audio.
+*   **`rate`**: `int` - Desired sample rate.
+*   **`channels`**: `int` - Number of audio channels.
+*   **`bufferLength`**: `int` - Size of the internal buffer for playback.
+*   **`deviceIndex`**: `int` - Index of the audio output device.
+*   **`input`**: `Signal1D` - The input signal that provides the audio data to be played.
+
+**Signals:**
+
+*   `activeChanged()`
+*   `rateChanged()`
+*   `channelsChanged()`
+*   `bufferLengthChanged()`
+*   `deviceIndexChanged()`
+*   `inputChanged()`
+
+**Methods/Slots:**
+
+*   Setting `active = true` starts playback.
+*   Setting `active = false` stops playback.
+*   `appendBuffer(offset, length)`: Internal slot connected to the `input.update` signal to queue data for playback.
+
+### RemoteAudioDevice
+
+The `RemoteAudioDevice` class allows receiving audio data from a network source.
+
+**Purpose:**
+
+To listen on a network port for incoming audio data and provide it as a `Signal1D` output.
+
+**Properties:**
+
+*   **`active`**: `bool` - Controls if the server is listening.
+*   **`port`**: `int` - The network port to listen on.
+*   **`bufferLength`**: `int` - Expected buffer length of incoming audio data.
+*   **`output`**: `Signal1D` (read-only) - The output signal carrying the received audio data.
+
+**Signals:**
+
+*   `activeChanged()`
+*   `portChanged()`
+*   `bufferLengthChanged()`
+*   `outputChanged()`
+*   `accept(string address)`: Emitted when a client connects.
+
+**Methods/Slots:**
+
+*   Setting `active = true` starts the server.
+*   Setting `active = false` would ideally stop the server (implementation details for stopping the thread might be needed).
+*   `startServer()`: Starts the listening thread.
+
+```

--- a/plugins/hcmusic/dsp/README.md
+++ b/plugins/hcmusic/dsp/README.md
@@ -1,0 +1,425 @@
+# HC Music DSP Nodes (`plugins/hcmusic/dsp/`)
+
+This directory contains classes for Digital Signal Processing (DSP) within the HC Music plugin system. These classes are designed to be used in a node-based pipeline, allowing for flexible construction of audio and signal processing chains, often controllable via QML.
+
+## Overall Architecture
+
+The DSP system is built around a node-based architecture. Each DSP unit is a "Node" that can be connected to other nodes. Typically, nodes have input and/or output "ports" that carry signal data or derived values.
+
+*   **Signal Data**: Audio or other 1D data is primarily handled by `Signal1D` objects (specifically `QtSignal1D`).
+*   **Nodes**: These are QML components (`QQuickItem`) that encapsulate specific DSP functionalities. They can be sources (like `SineSynth`), processors (like `FFT`, `RingBuffer`), or estimators (like `PitchTracker`, `Amplitude`).
+*   **Connections**: Nodes are connected by assigning the `output` of one node to the `input` of another. When the source node updates its data, it emits a signal that triggers the connected node to process the new data.
+
+## Core Data Structure
+
+### `Signal1D` (in `Node.py`)
+
+The `Signal1D` class is an abstract base class representing a 1-dimensional signal. It defines an interface for accessing signal properties and data.
+
+**Purpose:** To provide a standardized way to handle streams of 1D data, such as audio samples.
+
+**Key Properties:**
+
+*   `length`: `int` (read-only) - The number of frames or samples in the signal.
+*   `channels`: `int` (read-only) - The number of channels in the signal (e.g., 1 for mono, 2 for stereo).
+*   `buffer`: `QtCore.QByteArray` (read-only, abstract) - The raw buffer containing the signal data. The concrete implementation (`QtSignal1D`) provides this.
+
+**Key Signals:**
+
+*   `bufferChanged()`: Emitted when the underlying buffer object changes.
+*   `channelsChanged()`: Emitted when the number of channels changes.
+*   `lengthChanged()`: Emitted when the length of the signal changes.
+*   `update(offset, length)`: Emitted when a portion of the signal data has been updated. This is crucial for pipeline processing.
+
+**Key Methods (Abstract):**
+
+*   `slice(offset, length)`: Returns a QByteArray slice of the data.
+*   `alloc(length, channels)`: Allocates memory for the signal.
+*   `numpy_array`: Property to get a NumPy array view of the data (implemented in `QtSignal1D`).
+
+### `QtSignal1D` (in `Node.py`)
+
+This is the concrete implementation of `Signal1D` used throughout the DSP nodes.
+
+**Purpose:** To provide a tangible 1D signal object that stores data in a `QtCore.QByteArray` and allows efficient interaction with NumPy.
+
+**Implementation Details:**
+
+*   It stores data as a `QtCore.QByteArray`. Data is typically treated as 32-bit floating-point numbers (`np.float32`).
+*   `buffer`: Returns the internal `QByteArray`.
+*   `alloc(length, channels)`: Allocates a `QByteArray` of `length * channels * 4` bytes.
+*   `resize(length)`: Resizes the buffer.
+*   `reserve(length)`: Reserves memory, often to the next power of two, for efficiency.
+*   `numpy_array`: Provides a NumPy array that directly views the `QByteArray`'s data, allowing for efficient numerical operations. Changes to the NumPy array reflect in the `QByteArray` and vice-versa.
+
+## Base Node Classes
+
+These classes form the foundation for all DSP components.
+
+### `Node` (in `Node.py`)
+
+The most basic building block for DSP components in QML.
+
+**Purpose:** To provide a base `QQuickItem` that integrates with QML's lifecycle.
+
+**Key Features:**
+
+*   Inherits from `QtQuick.QQuickItem`.
+*   `componentComplete()`: A QML lifecycle method that is overridden to set a `completed` flag and call `initialize()`.
+*   `initialize()`: A virtual method intended to be overridden by derived classes for any setup required after QML component completion (e.g., allocating output buffers).
+
+### `EstimateNode` (in `Node.py`)
+
+A base class for nodes that analyze an input signal and produce some estimated value(s) or trigger events, rather than outputting another signal.
+
+**Purpose:** To process an input signal and derive data or insights from it.
+
+**Key Properties:**
+
+*   `input`: `Signal1D` - The input signal to be processed. When set, its `update` signal is connected to the node's internal `_update` slot.
+*   `running`: `bool` - If `true` (default), the node processes incoming data. If `false`, updates are ignored.
+
+**Key Signals:**
+
+*   `inputChanged()`: Emitted when the `input` property changes.
+*   `runningChanged()`: Emitted when the `running` property changes.
+
+**Key Methods:**
+
+*   `_update(offset, length)`: Internal slot called when the input signal updates. Calls `update()` if `running` is true.
+*   `update(offset, length)`: Abstract method that must be implemented by derived classes to perform the actual estimation logic.
+
+### `ProcessorNode` (in `Node.py`)
+
+A base class for nodes that take an input signal, process it, and produce an output signal.
+
+**Purpose:** To transform an input `Signal1D` into an output `Signal1D`.
+
+**Key Properties:**
+
+*   `input`: `Signal1D` - The input signal.
+*   `output`: `Signal1D` (read-only) - The output signal generated by the node. The type of this output signal is determined by the `output_class` argument passed to the constructor (typically `QtSignal1D`).
+*   `running`: `bool` - Controls processing.
+
+**Key Signals:**
+
+*   `inputChanged()`
+*   `outputChanged()`: Emitted when the `output` property object itself changes (rare).
+*   `runningChanged()`
+
+**Key Methods:**
+
+*   `_update(offset, length)`: Similar to `EstimateNode`, triggers `update()`.
+*   `update(offset, length)`: Abstract method for derived classes to implement the signal processing logic. Data from `self.input.numpy_array` is processed and written to `self.output.numpy_array`.
+
+## Concrete DSP Nodes
+
+### Buffer Nodes
+
+#### `RingBuffer` (in `Node.py`)
+
+A `ProcessorNode` that implements a fixed-size circular buffer.
+
+**Purpose:** To maintain a rolling window of the most recent signal data.
+
+**Key Properties:**
+
+*   `length`: `int` - The desired length (number of frames) of the ring buffer.
+*   `channels`: `int` - The number of channels for the buffer.
+
+**Key Signals:**
+
+*   `lengthChanged()`
+*   `channelsChanged()`
+
+**Operation:**
+
+*   `initialize()`: Allocates the `output` buffer to the specified `length` and `channels`.
+*   `update(offset, length)`: When new data arrives from `input`, it shifts the existing data in `output` and copies the new data into the end of the buffer. The `output` signal then emits `update(0, self.output.length)`.
+    *   Assertion: `length <= self.length` (incoming data block cannot be larger than the ring buffer's total length).
+
+#### `Storage` (in `Node.py`)
+
+A `ProcessorNode` that appends incoming data to its output buffer, up to an optional maximum length.
+
+**Purpose:** To collect or record signal data over time.
+
+**Key Properties:**
+
+*   `channels`: `int` - Number of channels for the storage.
+*   `maxLength`: `int` - The maximum number of frames to store. If 0, storage is unbounded (up to memory limits).
+*   `full`: `bool` (read-only) - True if `maxLength` is set and has been reached.
+
+**Key Signals:**
+
+*   `channelsChanged()`
+*   `maxLengthChanged()`
+*   `fullChanged()`
+
+**Operation:**
+
+*   `initialize()`: Allocates the `output` buffer with an initial length of 0.
+*   `update(offset, length)`: Appends the new data from `input.numpy_array` to `output.numpy_array`.
+    *   If `maxLength` is set, it only appends up to `maxLength`.
+    *   Resizes the `output` buffer as needed, potentially reserving more capacity.
+    *   Emits `output.update(old_length, new_data_length)`.
+
+### Analysis Nodes
+
+#### `FFT` (in `Node.py`)
+
+A `ProcessorNode` that computes the Fast Fourier Transform of the input signal.
+
+**Purpose:** To analyze the frequency spectrum of a signal.
+
+**Key Properties:**
+
+*   `rate`: `int` - The sample rate of the input signal. Used to calculate the frequency of the peak magnitude.
+*   `frequency`: `float` (read-only) - The frequency with the highest magnitude in the computed FFT.
+
+**Key Signals:**
+
+*   `frequencyChanged()`: Emitted when the `frequency` property changes.
+*   `rateChanged()`
+
+**Operation:**
+
+*   `initialize()`: Allocates the `output` buffer to match the dimensions of the `input` signal if available.
+*   `update(offset, length)`:
+    *   Computes `np.abs(np.fft.fft(input_data, axis=0))` and stores it in `output.numpy_array`.
+    *   Normalizes the output by its maximum value.
+    *   Calculates the dominant frequency based on the `rate` and the bin with the max magnitude.
+    *   Emits `output.update(0, length)`.
+
+#### `AutoCorrelation` (in `Node.py`)
+
+A `ProcessorNode` that computes the auto-correlation of the input signal.
+
+**Purpose:** Often used in pitch detection and analyzing periodicity.
+
+**Key Properties:**
+
+*   `rate`: `int` - Sample rate of the input, used to calculate frequency.
+*   `minShift`: `int` - Minimum lag (shift) for auto-correlation calculation.
+*   `maxShift`: `int` - Maximum lag for auto-correlation calculation.
+*   `windowSize`: `int` - The size of the window over which to compute the auto-correlation.
+*   `frequency`: `float` (read-only) - Estimated frequency based on the auto-correlation result (typically `rate / lag_of_min_autocorrelation_value`).
+
+**Key Signals:**
+
+*   `frequencyChanged()`
+*   `rateChanged()`
+*   `minShiftChanged()`
+*   `maxShiftChanged()`
+*   `windowSizeChanged()`
+
+**Operation:**
+
+*   `initialize()`: Allocates the `output` buffer to `maxShift + 1` length and 1 channel.
+*   `update(offset, length)`:
+    *   Uses a C++ backend (`cInspector.auto_correlation`) to compute auto-correlation for lags from `minShift` to `maxShift`.
+    *   Stores the result in `output.numpy_array`.
+    *   Estimates frequency based on the lag with the minimum value in the auto-correlation result within the specified shift range.
+    *   Emits `output.update(minShift, maxShift - minShift + 1)`.
+
+#### `PitchTracker` (in `AlgorithmNode.py`)
+
+An `EstimateNode` that estimates the musical pitch of an audio signal.
+
+**Purpose:** To determine the fundamental frequency and musical note of an incoming audio signal.
+
+**Key Properties:**
+
+*   `rate`: `int` - Sample rate of the input audio.
+*   `minLag`: `int` - Minimum lag for the internal auto-correlation.
+*   `maxLag`: `int` - Maximum lag for the internal auto-correlation.
+*   `windowSize`: `int` - Window size for auto-correlation.
+*   `threshold`: `int` - Threshold for peak/valley detection in the auto-correlation signal.
+*   `channel`: `int` - Selects which channel of the input signal to analyze.
+*   `frequency`: `float` (read-only) - Estimated fundamental frequency.
+*   `note`: `int` (read-only) - Estimated MIDI note number (rounded).
+*   `noteOnset`: `int` (read-only) - The note number at the most recent onset event.
+
+**Key Signals:**
+
+*   `frequencyChanged()`
+*   `noteChanged()`
+*   `noteOnsetChanged()`
+*   `rateChanged()`, `minLagChanged()`, `maxLagChanged()`, `windowSizeChanged()`, `thresholdChanged()`, `channelChanged()`
+*   `onset()`: Emitted when a new note onset is detected.
+*   `sustain()`: Emitted when the current note is sustained.
+*   `offset()`: Emitted when a note offset (silence or end of note) is detected.
+
+**Operation:**
+
+*   `update(offset, length)`:
+    *   Performs auto-correlation on the selected channel of the input data.
+    *   Uses `best_lag_analyze` (a custom peak/valley picking logic on the ACF) to find the dominant lag.
+    *   Calculates frequency from this lag and the `rate`.
+    *   Converts frequency to a (potentially non-integer) MIDI note.
+    *   Uses a `Smoother` class to process the raw note sequence and detect `onset`, `sustain`, and `offset` events.
+
+#### `Amplitude` (in `AlgorithmNode.py`)
+
+An `EstimateNode` that calculates the amplitude or envelope of an input signal.
+
+**Purpose:** To measure the loudness or overall level of a signal.
+
+**Key Properties:**
+
+*   `offset`: `int` - Interval length for peak detection in the envelope calculation. (The variable name `offset` here is a bit confusing, it means an interval or window for processing).
+*   `windowSize`: `int` - (Seems unused in the current `update` logic, but defined).
+*   `channel`: `int` - Selects which channel of the input signal to analyze.
+*   `amplitude`: `int` (read-only) - The calculated mean amplitude.
+
+**Key Signals:**
+
+*   `amplitudeChanged()`
+*   `offsetChanged()`
+*   `windowSizeChanged()`
+*   `channelChanged()`
+
+**Operation:**
+
+*   `update(offset, length)`:
+    *   Calls `getEnvelope` on the selected channel of the input data.
+    *   `getEnvelope`: Takes the absolute value of the signal, then finds local maximums over `intervalLength` (property `offset`) segments.
+    *   Calculates the mean of these detected peak values and sets it as `_amplitude`.
+    *   Emits `amplitudeChanged`. (Note: The signal emitted is `self.amplitudeChanged` but it should be `self.amplitudeChanged.emit()`).
+
+### Synthesis Nodes
+
+#### `SineSynth` (in `Synth.py`)
+
+A `Node` (not `ProcessorNode` or `EstimateNode` as it's a source) that generates a sine wave.
+
+**Purpose:** To produce a basic sinusoidal audio signal.
+
+**Key Properties:**
+
+*   `frequency`: `float` - Frequency of the sine wave in Hz.
+*   `rate`: `int` - Sample rate for the generated wave.
+*   `amplitude`: `float` - Amplitude of the sine wave (0.0 to 1.0 typically).
+*   `length`: `int` - The number of samples to generate per `synth()` call (i.e., buffer length).
+*   `phase`: `float` - Current phase of the oscillator, normalized to the range [0, 1). Updated after each `synth()` call to ensure phase continuity.
+*   `output`: `QtSignal1D` (read-only) - The output signal where the sine wave is written.
+
+**Key Signals:**
+
+*   `frequencyChanged()`, `rateChanged()`, `amplitudeChanged()`, `lengthChanged()`, `phaseChanged()`
+*   `outputChanged()`: When the output `QtSignal1D` object itself is replaced.
+
+**Key Slots/Methods:**
+
+*   `initialize()`: Allocates the `output` buffer.
+*   `synth()`: Generates `length` samples of a sine wave based on the current properties and updates `output.numpy_array`. It then emits `output.update(0, self.length)` and adjusts `phase` for continuity.
+
+## QML Usage Examples
+
+### Example 1: SineSynth -> RingBuffer -> FFT
+
+This example shows how to generate a sine wave, feed it into a ring buffer, and then analyze the buffer's content with an FFT node.
+
+```qml
+import QtQuick 2.15
+import hcmusic.dsp 1.0 // Assuming dsp module is registered
+
+Item {
+    SineSynth {
+        id: sine
+        frequency: 440 // A4 note
+        rate: 44100
+        amplitude: 0.8
+        length: 1024 // Buffer size for synth and FFT
+        Component.onCompleted: {
+            initialize(); // Initialize output buffer
+            synth(); // Generate initial data
+        }
+    }
+
+    RingBuffer {
+        id: ringBuffer
+        input: sine.output // Connect SineSynth output to RingBuffer input
+        length: sine.length // Match buffer lengths
+        channels: 1
+        Component.onCompleted: initialize()
+    }
+
+    FFT {
+        id: fft
+        input: ringBuffer.output // Connect RingBuffer output to FFT input
+        rate: sine.rate
+        Component.onCompleted: initialize()
+
+        // When FFT output is updated, log the dominant frequency
+        // output.update is a Signal1D signal
+        Connections {
+            target: fft.output
+            function onUpdate(offset, length) {
+                // console.log("FFT updated. Dominant frequency:", fft.frequency + " Hz");
+            }
+        }
+        // Or react to frequency property change
+        onFrequencyChanged: {
+             // console.log("Dominant frequency changed:", frequency + " Hz");
+        }
+    }
+
+    // To make it run continuously, you might use a Timer
+    Timer {
+        interval: Math.floor(sine.length / sine.rate * 1000) - 5 // ms, approx buffer duration
+        running: true
+        repeat: true
+        onTriggered: {
+            sine.synth(); // Generate new data, which will propagate
+                          // sine.output.update -> ringBuffer.update -> fft.update
+        }
+    }
+}
+```
+
+### Example 2: AudioInput -> PitchTracker
+
+This example conceptually shows how an audio input (like `AudioInputDevice` from `hcmusic.audio`) could be connected to a `PitchTracker`.
+
+```qml
+import QtQuick 2.15
+import hcmusic.dsp 1.0
+import hcmusic.audio 1.0 // Assuming audio module is registered
+
+Item {
+    // Assume AudioInputDevice is set up elsewhere or like this:
+    AudioInputDevice {
+        id: audioInput
+        active: true
+        rate: 44100
+        channels: 1
+        bufferLength: 1024 // PitchTracker works on chunks of data
+        // ... deviceIndex setup ...
+        Component.onCompleted: initialize()
+    }
+
+    PitchTracker {
+        id: pitchTracker
+        input: audioInput.output // Connect audio input to PitchTracker
+        rate: audioInput.rate
+        minLag: 32
+        maxLag: 500
+        windowSize: 256
+        threshold: 150000 // Adjust based on input signal level
+        channel: 0
+
+        onFrequencyChanged: {
+            // console.log("Estimated Frequency:", frequency.toFixed(2) + " Hz");
+        }
+        onNoteChanged: {
+            // console.log("Estimated Note (MIDI):", note);
+        }
+        onOnset: {
+            // console.log("Note Onset! Note:", note, "(", noteOnset, ")");
+        }
+    }
+}
+```
+
+This README provides a comprehensive overview of the DSP classes in `plugins/hcmusic/dsp/`. Refer to the individual source files (`Node.py`, `AlgorithmNode.py`, `Synth.py`) for complete implementation details.

--- a/plugins/hcmusic/licap/README.md
+++ b/plugins/hcmusic/licap/README.md
@@ -1,0 +1,135 @@
+# HC Music LiCAP Interface (`plugins/hcmusic/licap/`)
+
+This package provides an interface for LiCAP (Light Sensing Capacitive Array Peripheral) hardware devices, allowing them to be used as data sources within the HC Music plugin system, particularly in QML applications and with `hcmusic.dsp` nodes.
+
+## `QLiCAPv1` Class (in `Adapter.py`)
+
+The `QLiCAPv1` class is the primary interface for using LiCAP v1 hardware in QML. It acts as an adapter, fetching data from the LiCAP device and exposing it as a `Signal1D` compatible with the HC Music DSP node framework.
+
+**Purpose:**
+
+To connect to a LiCAP v1 device via a serial port, configure data acquisition parameters (like buffer length and selected channels), and provide the incoming sensor data as a continuous stream for further processing (e.g., by DSP nodes).
+
+**Underlying Mechanism:**
+
+`QLiCAPv1` uses an internal instance of `LiCAPv1` (from `LiCAPDevice.py`). The `LiCAPv1` object handles the low-level communication with the hardware. It runs in a separate thread, continuously reading data from the specified serial port, converting it, and then passing it to `QLiCAPv1` via a callback. `QLiCAPv1` accumulates this data into buffers of a specified `bufferLength` and then emits a signal when a full buffer is ready.
+
+**Key Properties:**
+
+*   **`active`**: `bool`
+    *   Controls whether the LiCAP device is currently capturing data.
+    *   Setting to `true` attempts to open the device on the specified `port` and start data acquisition.
+    *   Setting to `false` stops data acquisition and closes the device.
+*   **`port`**: `str` (originally `portName` in the task description, but the code uses `port`)
+    *   The name of the serial port where the LiCAP device is connected (e.g., "/dev/ttyUSB0", "COM3").
+    *   This must be set before activating the device.
+*   **`bufferLength`**: `int`
+    *   The number of samples (frames) to collect in each output buffer. Default is 256.
+    *   Note: Changing `bufferLength` while `active` is true is not supported and will raise an exception. It should be set before activation or when the device is inactive.
+*   **`channels`**: `list`
+    *   A list of integer indices specifying which channels from the LiCAP device should be included in the `output` signal. LiCAP v1 provides 6 channels (0-5). Default is `[0, 1, 2, 3, 4, 5]`.
+    *   The number of channels in the `output` signal will be `len(self.channels)`.
+    *   Note: Changing `channels` while `active` is true is not supported and will raise an exception.
+*   **`output`**: `Signal1D` (read-only)
+    *   The output signal that carries the captured LiCAP data. The data is a NumPy array accessible via `output.numpy_array`. Each row is a frame, and each column corresponds to a selected channel.
+
+**Signals:**
+
+*   **`activeChanged()`**: Emitted when the `active` property changes.
+*   **`portChanged()`**: Emitted when the `port` property changes.
+*   **`bufferLengthChanged()`**: Emitted when the `bufferLength` property changes.
+*   **`channelsChanged()`**: Emitted when the `channels` list changes.
+*   **`error(string message)`**: Emitted when an error occurs, e.g., if the device cannot be opened on the specified `port`.
+*   **`output.update(offset, length)`**: This signal, from the `QtSignal1D` object held by the `output` property, is emitted whenever a new buffer of LiCAP data (of `bufferLength` samples) is available. This effectively serves as the "data available" signal. `offset` is typically 0 and `length` is `bufferLength`.
+
+**Methods/Slots (Usage):**
+
+The primary way to control `QLiCAPv1` is by setting its properties:
+1.  Set the `port` property to the correct serial port name.
+2.  Optionally, set `bufferLength` to the desired number of samples per data block.
+3.  Optionally, set `channels` to select specific data channels from the LiCAP device.
+4.  Set `active = true` to start data acquisition. The `output.update` signal will then be emitted periodically as new data buffers become available.
+5.  Set `active = false` to stop data acquisition.
+
+The `initialize()` method is called automatically when the QML component is complete. If `active` is already true at that point, it will attempt to open the device.
+
+**QML Example:**
+
+This example demonstrates how to instantiate `QLiCAPv1`, configure it, and connect its output to a `RingBuffer` (from `hcmusic.dsp`).
+
+```qml
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import hcmusic.dsp 1.0      // Assuming dsp module is registered
+import hcmusic.licap 1.0    // Assuming licap module is registered
+
+ApplicationWindow {
+    visible: true
+    width: 640
+    height: 480
+    title: "LiCAPv1 Example"
+
+    QLiCAPv1 {
+        id: licapSource
+        port: "/dev/ttyUSB0" // Change to your LiCAP device's serial port
+        bufferLength: 512
+        channels: [0, 1, 2] // Select first 3 channels
+        active: false        // Start inactive
+
+        onError: function(message) {
+            console.error("LiCAP Error:", message);
+            statusLabel.text = "Error: " + message;
+        }
+
+        // The output.update signal indicates new data is ready
+        // We don't connect to it directly here, as RingBuffer will do it.
+    }
+
+    RingBuffer {
+        id: dataBuffer
+        input: licapSource.output // Connect LiCAP output to RingBuffer input
+        length: licapSource.bufferLength // Match buffer length
+        channels: licapSource.channels.length // Match number of selected channels
+        Component.onCompleted: initialize() // Important for RingBuffer
+    }
+
+    // Example: Displaying the status and a button to start/stop
+    Column {
+        anchors.centerIn: parent
+        spacing: 10
+
+        Label {
+            id: statusLabel
+            text: licapSource.active ? "Capturing from LiCAP" : "LiCAP Inactive"
+        }
+
+        Button {
+            text: licapSource.active ? "Stop LiCAP" : "Start LiCAP"
+            onClicked: {
+                licapSource.active = !licapSource.active;
+            }
+        }
+
+        Label {
+            text: "Port: " + licapSource.port
+        }
+        Label {
+            text: "Buffer Length: " + licapSource.bufferLength
+        }
+        Label {
+            text: "Selected Channels Count: " + licapSource.channels.length
+        }
+    }
+
+    // To do something with the data in dataBuffer:
+    // Connections {
+    //     target: dataBuffer.output
+    //     function onUpdate(offset, length) {
+    //         console.log("RingBuffer updated with LiCAP data. Length:", length);
+    //         // dataBuffer.output.numpy_array contains the data
+    //     }
+    // }
+}
+```
+
+This README provides an overview of how to use the `QLiCAPv1` class to interface with LiCAP hardware in QML applications. For more details on the underlying serial communication and data processing, refer to `LiCAPDevice.py`.

--- a/plugins/hcmusic/midi/README.md
+++ b/plugins/hcmusic/midi/README.md
@@ -1,0 +1,180 @@
+# HC Music MIDI Output (`plugins/hcmusic/midi/`)
+
+This package provides classes for MIDI (Musical Instrument Digital Interface) output functionality within the HC Music plugin system. It allows QML applications to discover available MIDI output ports and send various MIDI messages to them.
+
+## `MidiDiscoveryModelProvider` Class
+
+The `MidiDiscoveryModelProvider` class is responsible for discovering and listing available MIDI output devices on the system.
+
+**Purpose:**
+
+To provide a QML-accessible model of available MIDI output ports, enabling users or applications to select a MIDI device for output.
+
+**Key Properties/Models:**
+
+*   **`midiDeviceModel`**: `MidiDeviceModel` (read-only)
+    *   An instance of `MidiDeviceModel` that holds the list of discovered MIDI output devices. This model can be directly used by QML views like `ComboBox` or `ListView`.
+
+**`MidiDeviceModel` (Internal Model used by `midiDeviceModel` property):**
+
+The `MidiDeviceModel` is a `QAbstractListModel` that stores information about each discovered MIDI output port.
+
+*   **Roles:**
+    *   `name` (`Qt.UserRole + 1`): The human-readable name of the MIDI output port (e.g., "USB MIDI Interface", "Microsoft GS Wavetable Synth").
+    *   `deviceIndex` (`Qt.UserRole + 2`): The index of the device in the list. (Note: The actual port name is used for opening devices with `MidiOutputDevice`).
+
+**Methods:**
+
+*   **`refresh()`**: `Slot()`
+    *   Scans the system for available MIDI output ports using `mido.get_output_names()` and updates the `midiDeviceModel` with the found ports. This should be called to populate or update the list.
+*   **`find(part_name)`**: `Slot(str, result=str)`
+    *   Searches through the available MIDI output port names and returns the full name of the first device that contains `part_name` as a substring. This is case-sensitive.
+    *   Example: `find("USB")` might return "Focusrite USB MIDI".
+
+## `MidiOutputDevice` Class
+
+The `MidiOutputDevice` class is used to send MIDI messages to a selected MIDI output port.
+
+**Purpose:**
+
+To open a specific MIDI output port and send various types of MIDI messages, such as note on/off, control changes, pitch wheel, etc.
+
+**Key Properties:**
+
+*   **`portName`**: `str`
+    *   The name of the MIDI output port to which messages will be sent.
+    *   Setting this property attempts to:
+        1.  Close any previously opened port.
+        2.  Open the new port specified by `val` using `mido.open_output(val)`.
+        3.  If successful, the `opened` property becomes `true`.
+    *   The port name must be one of the names available from `mido.get_output_names()` (which `MidiDiscoveryModelProvider` lists).
+*   **`opened`**: `bool` (read-only)
+    *   Indicates whether the MIDI port specified by `portName` is currently open and ready to send messages.
+
+**Methods/Slots for Sending MIDI Messages:**
+
+Once `portName` is set and `opened` is `true`, the following slots can be called to send MIDI messages. All message sending methods check if the `outport` is valid and open before attempting to send.
+
+*   **`note_on(channel, note, velocity)`**: `Slot(int, int, int)`
+    *   Sends a Note On message.
+    *   `channel`: MIDI channel (0-15).
+    *   `note`: MIDI note number (0-127).
+    *   `velocity`: Note velocity (0-127).
+*   **`note_off(channel, note, velocity)`**: `Slot(int, int, int)`
+    *   Sends a Note Off message.
+    *   Parameters are the same as `note_on`. (Velocity in Note Off is often used for release velocity).
+*   **`polytouch(channel, note, value)`**: `Slot(int, int, int)`
+    *   Sends a Polyphonic Aftertouch (Key Pressure) message.
+    *   `channel`: MIDI channel (0-15).
+    *   `note`: MIDI note number (0-127) for which the pressure applies.
+    *   `value`: Pressure value (0-127).
+*   **`control_change(channel, control, value)`**: `Slot(int, int, int)`
+    *   Sends a Control Change (CC) message.
+    *   `channel`: MIDI channel (0-15).
+    *   `control`: CC number (0-127) (e.g., 1 for modulation, 7 for volume).
+    *   `value`: CC value (0-127).
+*   **`program_change(channel, program)`**: `Slot(int, int)`
+    *   Sends a Program Change message.
+    *   `channel`: MIDI channel (0-15).
+    *   `program`: Program/patch number (0-127).
+*   **`aftertouch(channel, value)`**: `Slot(int, int)`
+    *   Sends a Channel Aftertouch (Channel Pressure) message.
+    *   `channel`: MIDI channel (0-15).
+    *   `value`: Pressure value (0-127).
+*   **`pitchwheel(channel, pitch)`**: `Slot(int, int)`
+    *   Sends a Pitch Wheel Change message.
+    *   `channel`: MIDI channel (0-15).
+    *   `pitch`: Pitch bend value. Typically a 14-bit value, `mido` expects a signed integer from -8192 to +8191. (0 is center).
+*   **`sysex(data)`**: `Slot(list)` (Note: The code shows `Slot(int)`, but `mido.Message('sysex', data=data)` expects `data` to be a list or tuple of integers (0-127)).
+    *   Sends a System Exclusive (SysEx) message.
+    *   `data`: A list of integers representing the SysEx data bytes (excluding the initial 0xF0 and final 0xF7, which `mido` adds).
+
+## QML Examples
+
+### Example 1: Listing MIDI Devices and Sending a Note
+
+This example shows how to use `MidiDiscoveryModelProvider` to populate a ComboBox with available MIDI output devices, and then use `MidiOutputDevice` to send a "Note On" message to the selected device.
+
+```qml
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import hcmusic.midi 1.0 // Assuming the module is registered
+
+ApplicationWindow {
+    visible: true
+    width: 400
+    height: 300
+    title: "MIDI Output Example"
+
+    MidiDiscoveryModelProvider {
+        id: midiDiscovery
+        Component.onCompleted: {
+            midiDiscovery.refresh(); // Populate the model on startup
+        }
+    }
+
+    MidiOutputDevice {
+        id: midiOut
+        // portName will be set from the ComboBox
+    }
+
+    Column {
+        anchors.fill: parent
+        padding: 10
+        spacing: 10
+
+        Label {
+            text: "Select MIDI Output Device:"
+        }
+
+        ComboBox {
+            id: midiDeviceSelector
+            width: parent.width
+            model: midiDiscovery.midiDeviceModel
+            textRole: "name" // Use the 'name' role from MidiDeviceModel
+
+            onCurrentTextChanged: {
+                // When selection changes, set the portName for MidiOutputDevice
+                if (currentText) {
+                    midiOut.portName = currentText;
+                }
+            }
+        }
+
+        Label {
+            text: "MIDI Port Status: " + (midiOut.opened ? "Open (" + midiOut.portName + ")" : "Closed")
+        }
+
+        Button {
+            text: "Send Note On (C4)"
+            enabled: midiOut.opened
+            onClicked: {
+                // Send a Middle C (note 60) on channel 0 with velocity 100
+                midiOut.note_on(0, 60, 100);
+                // Optionally, send a Note Off after a delay using a Timer
+                noteOffTimer.start();
+            }
+        }
+        
+        Button {
+            text: "Send Note Off (C4)"
+            enabled: midiOut.opened
+            onClicked: {
+                // Send a Middle C (note 60) on channel 0 with velocity 0
+                midiOut.note_off(0, 60, 0);
+            }
+        }
+    }
+
+    Timer {
+        id: noteOffTimer
+        interval: 500 // ms
+        onTriggered: {
+            midiOut.note_off(0, 60, 0);
+        }
+    }
+}
+```
+
+This README provides an overview of the MIDI output classes in `plugins/hcmusic/midi/`. For more details on MIDI messages and `mido` usage, refer to the `mido` library documentation.
+```

--- a/plugins/hcmusic/serial/README.md
+++ b/plugins/hcmusic/serial/README.md
@@ -1,61 +1,134 @@
 # hcmusic.serial Module
+
 ## Introduction
-This module provide serial access to QML.
+This module provides serial communication functionalities for QML applications, including device discovery and a proposed interface for serial port operations.
 
-## VCPDiscoveryModel
-Properties:
-- idFilter regex for vid:pid
-- running bool
+## `VCPDiscoveryModel`
 
-Turn on running and that's it. It will continiously scan for devices every second.
-**(No Thread)**
+This component continuously scans for connected Virtual COM Ports (VCP) that match a specified filter, making them available as a QML model. It operates using a `QTimer` and does not run in a separate thread.
+
+**Properties:**
+
+*   **`idFilter`**: `regexp`
+    *   A QML RegExp literal (or a `Qt.RegExp` object) used to filter devices based on their USB Vendor ID (VID) and Product ID (PID).
+    *   The filter pattern should match the format "VID:PID", where VID and PID are 4-digit hexadecimal numbers.
+    *   Example: `/0403:\\d+/` would match devices with Vendor ID `0403` (commonly FTDI) and any Product ID.
+    *   Default: `/\d\d\d\d:\d\d\d\d/` (matches any valid VID:PID format).
+*   **`running`**: `bool`
+    *   Set to `true` to start scanning for devices (typically every second).
+    *   Set to `false` to stop scanning.
+
+**Example Usage:**
+
+Turn on `running` and set an optional `idFilter`. The model will automatically update.
+
 ```qml
-VCPDiscoveryModel {
-    id: vcpScanner
-    running: true
-    idFilter: /0403:\d+/
-}
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import hcmusic.serial 1.0 // Assuming module registration
 
-ComboBox {
-    model: vcpScanner
-    textRole: 'device'
+Column {
+    VCPDiscoveryModel {
+        id: vcpScanner
+        running: true
+        // Example: Filter for devices with VID 0403 (FTDI) and any PID
+        idFilter: /0403:\d+/ 
+        // Example: Filter for a specific device (e.g., VID:PID 1A86:7523)
+        // idFilter: /1a86:7523/
+    }
+
+    ComboBox {
+        width: 200
+        model: vcpScanner
+        textRole: "device" // Display the port name
+        onCurrentTextChanged: {
+            if (currentIndex !== -1) {
+                var currentDevice = vcpScanner.get(currentIndex); // Requires QAbstractListModel get method
+                console.log("Selected device:", currentDevice.device, 
+                            "VID:", currentDevice.usbVendorId.toString(16), // Display VID in hex
+                            "PID:", currentDevice.usbProductId.toString(16)); // Display PID in hex
+            }
+        }
+    }
 }
 ```
+*(Note: Accessing model data like `vcpScanner.get(currentIndex)` as shown above requires the model to expose such a method, or for direct property access if using `DelegateModel` or similar. The example focuses on `textRole` which is standard.)*
 
-### Available Roles
-- device - port name
-- usbVendorId
-- usbProductId
+**Available Model Roles:**
 
-## SerialPort Draft
-Properties:
-- port string
-- baudRate int (default to 9600)
-- byteSize int (default to 8)
-- parity bool (default to False)
-- stopbits int (default to 1)
-- (To be discus) pattern str (default to '8N1')
-- rtscts bool
-- dtsdtr bool
+*   **`device`**: `string` - The port name that can be used to open the serial port (e.g., "COM3", "/dev/ttyUSB0").
+*   **`usbVendorId`**: `int` - The USB Vendor ID of the device (e.g., `0x0403`).
+*   **`usbProductId`**: `int` - The USB Product ID of the device (e.g., `0x7523`).
 
-Signals:
-- error
-- data(ArrayBuffer message)
+*(The `Serial.py` code also includes a "TODO Export more info to QML". Additional roles like description or manufacturer could be added in the future.)*
 
-Slots:
-- send(ArrayBuffer message)
-- recv(int length) - Receive specific bytes
+## `SerialPort` (Draft / Proposed API)
 
-### Example Usage
+**Note: The `SerialPort` component described below is a DRAFT and is NOT YET IMPLEMENTED in `Serial.py`. This section outlines a proposed API for future development.**
+
+This component would provide an interface for direct serial port communication.
+
+**Proposed Properties:**
+
+*   **`port`**: `string` - The name of the serial port to connect to (e.g., "COM3", obtained from `VCPDiscoveryModel`).
+*   **`baudRate`**: `int` - The serial baud rate (e.g., 9600, 115200). Default: 9600.
+*   **`byteSize`**: `int` - Number of data bits. Default: 8.
+*   **`parity`**: `enum` - Parity setting (e.g., None, Even, Odd). Default: None. (In Python's `pyserial`, this is typically a string like 'N', 'E', 'O').
+*   **`stopbits`**: `int` or `float` - Number of stop bits (e.g., 1, 1.5, 2). Default: 1.
+*   **`pattern`**: `string` - A shorthand string to set `byteSize`, `parity`, and `stopbits`.
+    *   Example: "8N1" (8 data bits, No parity, 1 stop bit). This is a common way to specify serial parameters. (Still marked "To be discus[sed]" in the original draft).
+*   **`rtscts`**: `bool` - Enable RTS/CTS hardware flow control. Default: `false`.
+*   **`dtsdtr`**: `bool` - Enable DSR/DTR hardware flow control. Default: `false`.
+*   **`opened`**: `bool` (read-only) - Indicates if the port is successfully opened.
+
+**Proposed Signals:**
+
+*   **`error(string message, int code)`**: Emitted when an error occurs (e.g., port not found, permission denied, configuration error).
+*   **`data(ArrayBuffer message)`**: Emitted when new data is received from the serial port. The data is provided as an `ArrayBuffer`.
+
+**Proposed Slots (Methods):**
+
+*   **`send(ArrayBuffer message)`**: Sends binary data from an `ArrayBuffer` to the serial port.
+*   **`sendString(string message, string encoding = "utf-8")`**: Sends string data, encoded appropriately.
+*   **`recv(int length)`**: (Potentially problematic due to blocking) Attempts to receive a specific number of bytes. *Note: Synchronous `recv` methods can block the QML thread; an asynchronous, signal-based approach for receiving data (like the `data` signal) is generally preferred.*
+*   **`open()`**: Explicitly opens the port if `port` and other parameters are set.
+*   **`close()`**: Closes the port.
+
+**Draft Example Usage:**
+
 ```qml
+import QtQuick 2.12
+import hcmusic.serial 1.0 // Assuming module registration
+
 SerialPort {
-    port: 'COM3'
-    pattern: '8N1'
-    onError: {
+    id: mySerialPort
+    port: "COM3" // Set this from VCPDiscoveryModel or user input
+    baudRate: 115200
+    // pattern: "8N1" // Alternatively, use pattern
 
+    onError: function(message, code) {
+        console.error("Serial Error:", message, "Code:", code);
     }
-    onData: {
-        console.log(new Uint8Array(message))
+
+    onData: function(arrayBufferData) {
+        var dataView = new Uint8Array(arrayBufferData);
+        console.log("Data received (Uint8Array):", dataView);
+        // Or process as string if applicable:
+        // var textDecoder = new TextDecoder('utf-8');
+        // console.log("Data received (string):", textDecoder.decode(arrayBufferData));
+    }
+
+    Component.onCompleted: {
+        // Example: Sending data after the port is configured (and ideally checked if open)
+        // This requires the port to be opened, either automatically on setting 'port'
+        // or by an explicit open() call.
+        // For a robust application, check mySerialPort.opened status.
+        
+        // var dataToSend = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+        // mySerialPort.send(dataToSend.buffer); 
+        
+        // mySerialPort.sendString("Hello Serial!");
     }
 }
 ```
+This draft API provides a starting point for a QML-friendly serial port component. The actual implementation would need to handle threading for non-blocking operations carefully.

--- a/plugins/hcmusic/utils/README.md
+++ b/plugins/hcmusic/utils/README.md
@@ -1,0 +1,152 @@
+# HC Music Utilities (`plugins/hcmusic/utils/`)
+
+This directory contains utility components for the HC Music QML plugin system.
+
+## `TimeoutModel.qml`
+
+A specialized QML `ListModel` where items can be marked as inactive ("grayed out") after a certain duration and then automatically removed after a longer timeout. This is useful for displaying transient information or events that should fade and then disappear.
+
+**Purpose:**
+
+To manage lists of temporary items, visually indicating their age by changing their state and eventually removing them, without manual intervention for each item's lifecycle.
+
+**Key Properties:**
+
+*   **`timeout`**: `real` (default: `4000` ms)
+    *   The total duration (in milliseconds) an item will remain in the model before being automatically removed.
+*   **`grayout`**: `real` (default: `timeout - 1000` ms, i.e., `3000` ms by default)
+    *   The duration (in milliseconds) after which an item in the model will have its `active` role set to `false`. This allows UI delegates to visually distinguish "aging" items (e.g., by changing their color or opacity).
+    *   It is expected that `grayout < timeout`.
+
+**Key Function:**
+
+*   **`update(key, modelData, userData)`**:
+    *   Adds a new item to the model or refreshes an existing one.
+    *   **`key`**: `string` or `variant` - A unique identifier for the item. If an item with this `key` already exists in the model, its timestamp is refreshed, its `active` state is set to `true`, and its data is updated with `modelData`. If the `key` is new, a new item is appended.
+    *   **`modelData`**: `object` - A JavaScript object containing the data roles for the item (e.g., `{ name: "Event A", value: 123 }`). The `TimeoutModel` will automatically add or update an `active: true` role to this object when the item is added or refreshed.
+    *   **`userData`**: `variant` (optional) - Arbitrary data that can be associated with the item. This data is stored internally by the model but is not directly exposed as a model role. It can be useful for more complex scenarios where extra context is needed when an item is interacted with or processed.
+
+**Lifecycle of Items:**
+
+1.  **Addition/Update**: When `update()` is called:
+    *   If the `key` is new, a new item is appended to the model. `active` is set to `true`.
+    *   If the `key` exists, the existing item is updated. Its `active` role is set to `true`, its data roles are updated from `modelData`, and its internal timestamp is reset to the current time.
+2.  **Grayout**: A `Timer` within `TimeoutModel` periodically checks the age of items.
+    *   When the time elapsed since an item's last update (`timestamp`) is greater than or equal to `grayout`, its `active` role is set to `false` (i.e., `root.set(index, {active: false})`).
+3.  **Removal**:
+    *   When the time elapsed since an item's last update is greater than or equal to `timeout`, the item is automatically removed from the model.
+
+**QML Example:**
+
+```qml
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import hcmusic.utils 1.0 // Assuming module registration
+
+ApplicationWindow {
+    visible: true
+    width: 400
+    height: 300
+    title: "TimeoutModel Example"
+
+    TimeoutModel {
+        id: eventModel
+        timeout: 5000 // Items removed after 5 seconds
+        grayout: 3000 // Items marked inactive after 3 seconds
+    }
+
+    Column {
+        anchors.fill: parent
+        spacing: 10
+        padding: 10
+
+        Button {
+            text: "Add/Update Event A"
+            onClicked: {
+                eventModel.update("eventA", { 
+                    description: "Critical Alert", 
+                    value: Math.random().toFixed(2) 
+                }, {
+                    details: "Some extra context for Event A" 
+                });
+            }
+        }
+
+        Button {
+            text: "Add/Update Event B"
+            onClicked: {
+                eventModel.update("eventB", { 
+                    description: "Warning Message", 
+                    value: Math.floor(Math.random() * 100)
+                });
+            }
+        }
+
+        ListView {
+            width: parent.width
+            height: 200
+            model: eventModel
+            delegate: Rectangle {
+                width: ListView.view.width
+                height: 40
+                color: model.active ? "lightgreen" : "lightgray" // Change color based on 'active' state
+                border.color: "gray"
+
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    anchors.leftMargin: 5
+                    text: model.description + ": " + model.value
+                    font.strikeout: !model.active // Example: strikeout if not active
+                }
+
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.right: parent.right
+                    anchors.rightMargin: 5
+                    text: model.active ? "Active" : "Inactive"
+                    font.italic: !model.active
+                }
+                
+                // To access userData (not directly a model role):
+                // You would typically do this if you had a reference to the
+                // internal 'priv.metaData[key].userData' via a custom function
+                // in TimeoutModel or if the delegate had access to the key.
+            }
+        }
+    }
+}
+```
+
+## `NpzFile.py`
+
+This Python file (`plugins/hcmusic/utils/NpzFile.py`) contains a commented-out Python class named `NpzFile`.
+
+**Intended Purpose (based on the commented code):**
+
+The class appears to be designed as a node (possibly for a DSP/data processing chain) that would:
+1.  Take a `filename` (as a `QUrl`) pointing to a NumPy `.npz` archive file.
+2.  Load the `.npz` file using `numpy.load()`.
+3.  Extract an array named `'arr_0'` from the archive.
+4.  Process this array (convert to `float32`, transpose).
+5.  Make this data available as an output signal (presumably via a `SignalOutput` object, which is not defined in this file but likely part of the broader `hcmusic` framework).
+
+**Current Status:**
+
+The `NpzFile` class is **currently not active** as its entire implementation is commented out in the Python file. It represents a potential future utility for loading data from NumPy's compressed archive format.
+
+## C++ Extension (`hcmusic-utils`)
+
+The `qmldir` file for this module includes the line:
+```
+plugin hcmusic-utils
+```
+This signifies that a native C++ plugin (e.g., `hcmusic-utils.dll` on Windows, `libhcmusic-utils.so` on Linux) is associated with the `hcmusic.utils` QML module.
+
+While `TimeoutModel.qml` is a pure QML component, this C++ plugin might provide:
+*   Performance-critical helper functions or classes for other utilities within this module (though none are explicitly imported or used by `TimeoutModel.qml`).
+*   Underlying implementations for other components that might be part of the `hcmusic` ecosystem.
+*   Future utilities that require native code for performance or system access.
+
+Currently, there are no QML components in this directory that directly expose functionalities from this C++ plugin to the QML user. Its role is likely supportive or for other parts of the broader plugin system.
+```


### PR DESCRIPTION
This commit adds README.md files for various packages within the `plugins/hcmusic` directory, including `audio`, `dsp`, `licap`, `midi`, and `utils`.

It also includes updates to the existing READMEs for `plot` and `serial` packages.

The documentation covers the purpose, API (properties, signals, methods/slots), and QML usage examples for the components within these packages.

Note: The update for `plugins/hcmusic/plot/README.md` was prepared, but I encountered persistent errors and could not write it to the file system. The intended content for this file is available in my operational history.